### PR TITLE
Add overall subquery steps limit

### DIFF
--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -486,6 +486,7 @@ func (t *Cortex) initQueryFrontendTripperware() (serv services.Service, err erro
 		t.Overrides,
 		queryAnalyzer,
 		t.Cfg.Querier.DefaultEvaluationInterval,
+		t.Cfg.Querier.MaxSubQueryTotalSteps,
 	)
 
 	return services.NewIdleService(nil, func(_ error) error {
@@ -505,7 +506,7 @@ func (t *Cortex) initQueryFrontend() (serv services.Service, err error) {
 
 	// Wrap roundtripper into Tripperware.
 	roundTripper = t.QueryFrontendTripperware(roundTripper)
-
+	t.Cfg.Frontend.Handler.DefaultEvaluationInterval = t.Cfg.Querier.DefaultEvaluationInterval
 	handler := transport.NewHandler(t.Cfg.Frontend.Handler, roundTripper, util_log.Logger, prometheus.DefaultRegisterer)
 	t.API.RegisterQueryFrontendHandler(handler)
 

--- a/pkg/frontend/transport/handler.go
+++ b/pkg/frontend/transport/handler.go
@@ -73,6 +73,8 @@ type HandlerConfig struct {
 	LogQueriesLongerThan time.Duration `yaml:"log_queries_longer_than"`
 	MaxBodySize          int64         `yaml:"max_body_size"`
 	QueryStatsEnabled    bool          `yaml:"query_stats_enabled"`
+
+	DefaultEvaluationInterval time.Duration `yaml:"-"`
 }
 
 func (cfg *HandlerConfig) RegisterFlags(f *flag.FlagSet) {
@@ -339,6 +341,11 @@ func (f *Handler) reportQueryStats(r *http.Request, userID string, queryString u
 
 	if query := queryString.Get("query"); len(query) > 0 {
 		logMessage = append(logMessage, "query_length", len(query))
+		totalSubquerySteps, maxSubquerySteps := tripperware.GetSubQueryStepsFromQuery(query, f.cfg.DefaultEvaluationInterval)
+		if totalSubquerySteps > 0 {
+			logMessage = append(logMessage, "total_subquery_steps", totalSubquerySteps)
+			logMessage = append(logMessage, "max_subquery_steps", maxSubquerySteps)
+		}
 	}
 	if ua := r.Header.Get("User-Agent"); len(ua) > 0 {
 		logMessage = append(logMessage, "user_agent", ua)

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -63,6 +63,9 @@ type Config struct {
 	// step if not specified.
 	DefaultEvaluationInterval time.Duration `yaml:"default_evaluation_interval"`
 
+	// Max allowed sub query total steps.
+	MaxSubQueryTotalSteps int `yaml:"max_subquery_total_steps"`
+
 	// Directory for ActiveQueryTracker. If empty, ActiveQueryTracker will be disabled and MaxConcurrent will not be applied (!).
 	// ActiveQueryTracker logs queries that were active during the last crash, but logs them on the next startup.
 	// However, we need to use active query tracker, otherwise we cannot limit Max Concurrent queries in the PromQL
@@ -107,6 +110,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.EnablePerStepStats, "querier.per-step-stats-enabled", false, "Enable returning samples stats per steps in query response.")
 	f.DurationVar(&cfg.MaxQueryIntoFuture, "querier.max-query-into-future", 10*time.Minute, "Maximum duration into the future you can query. 0 to disable.")
 	f.DurationVar(&cfg.DefaultEvaluationInterval, "querier.default-evaluation-interval", time.Minute, "The default evaluation interval or step size for subqueries.")
+	f.IntVar(&cfg.MaxSubQueryTotalSteps, "querier.max-subquery-total-steps", 1000000, "Max allowed total subquery steps for each query.")
 	f.DurationVar(&cfg.QueryStoreAfter, "querier.query-store-after", 0, "The time after which a metric should be queried from storage and not just ingesters. 0 means all queries are sent to store. When running the blocks storage, if this option is enabled, the time range of the query sent to the store will be manipulated to ensure the query end is not more recent than 'now - query-store-after'.")
 	f.StringVar(&cfg.ActiveQueryTrackerDir, "querier.active-query-tracker-dir", "./active-query-tracker", "Active query tracker monitors active queries, and writes them to the file in given directory. If Cortex discovers any queries in this log during startup, it will log them to the log file. Setting to empty value disables active query tracker, which also disables -querier.max-concurrent option.")
 	f.StringVar(&cfg.StoreGatewayAddresses, "querier.store-gateway-addresses", "", "Comma separated list of store-gateway addresses in DNS Service Discovery format. This option should be set when using the blocks storage and the store-gateway sharding is disabled (when enabled, the store-gateway instances form a ring and addresses are picked from the ring).")

--- a/pkg/querier/tripperware/queryrange/query_range_middlewares_test.go
+++ b/pkg/querier/tripperware/queryrange/query_range_middlewares_test.go
@@ -74,6 +74,7 @@ func TestRoundTrip(t *testing.T) {
 		nil,
 		qa,
 		time.Minute,
+		100000,
 	)
 
 	for i, tc := range []struct {

--- a/pkg/querier/tripperware/roundtrip.go
+++ b/pkg/querier/tripperware/roundtrip.go
@@ -103,6 +103,7 @@ func NewQueryTripperware(
 	limits Limits,
 	queryAnalyzer querysharding.Analyzer,
 	defaultSubQueryInterval time.Duration,
+	maxSubQueryTotalSteps int,
 ) Tripperware {
 	// Per tenant query metrics.
 	queriesPerTenant := promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{
@@ -145,7 +146,7 @@ func NewQueryTripperware(
 				if isQuery || isQueryRange {
 					query := r.FormValue("query")
 					// Check subquery step size.
-					if err := SubQueryStepSizeCheck(query, defaultSubQueryInterval, MaxStep); err != nil {
+					if err := SubQueryStepSizeCheck(query, defaultSubQueryInterval, MaxStep, maxSubQueryTotalSteps); err != nil {
 						return nil, err
 					}
 				}

--- a/pkg/querier/tripperware/roundtrip_test.go
+++ b/pkg/querier/tripperware/roundtrip_test.go
@@ -147,7 +147,7 @@ func TestRoundTrip(t *testing.T) {
 		},
 		{
 			path:        querySubqueryStepSizeTooSmall,
-			expectedErr: httpgrpc.Errorf(http.StatusBadRequest, ErrSubQueryStepTooSmall, 11000),
+			expectedErr: httpgrpc.Errorf(http.StatusBadRequest, ErrSubQueryStepTooSmall, 11000, 30*24*60),
 			limits:      defaultOverrides,
 		},
 	} {
@@ -177,6 +177,7 @@ func TestRoundTrip(t *testing.T) {
 				tc.limits,
 				querysharding.NewQueryAnalyzer(),
 				time.Minute,
+				100000,
 			)
 			resp, err := tw(downstream).RoundTrip(req)
 			if tc.expectedErr == nil {

--- a/pkg/querier/tripperware/subquery.go
+++ b/pkg/querier/tripperware/subquery.go
@@ -9,35 +9,82 @@ import (
 )
 
 var (
-	ErrSubQueryStepTooSmall = "exceeded maximum resolution of %d points per timeseries in subquery. Try increasing the step size of your subquery"
+	ErrSubQueryStepTooSmall       = "exceeded maximum resolution of %d points per timeseries in subquery, got %d steps. Try increasing the step size of your subquery"
+	ErrSubQueryTotalStepsExceeded = "exceeded total allowed number of subquery steps %d in the query, got %d steps."
 )
 
 const (
 	MaxStep = 11000
 )
 
-// SubQueryStepSizeCheck ensures the query doesn't contain too small step size in subqueries.
-func SubQueryStepSizeCheck(query string, defaultSubQueryInterval time.Duration, maxStep int64) error {
+// SubQueryStepSizeCheck ensures the query doesn't contain too small step size and too many total steps in subqueries.
+func SubQueryStepSizeCheck(query string, defaultSubQueryInterval time.Duration, maxStep, maxTotalSteps int) error {
+	totalSteps, maxSteps := GetSubQueryStepsFromQuery(query, defaultSubQueryInterval)
+	if maxSteps > maxStep {
+		return httpgrpc.Errorf(http.StatusBadRequest, ErrSubQueryStepTooSmall, maxStep, maxSteps)
+	}
+	if totalSteps > maxTotalSteps {
+		return httpgrpc.Errorf(http.StatusBadRequest, ErrSubQueryTotalStepsExceeded, maxTotalSteps, totalSteps)
+	}
+	return nil
+}
+
+// GetSubQueryStepsFromQuery returns total steps of subqueries for the given query.
+func GetSubQueryStepsFromQuery(query string, defaultSubQueryInterval time.Duration) (int, int) {
 	expr, err := parser.ParseExpr(query)
 	if err != nil {
 		// If query fails to parse, we don't throw step size error
 		// but fail query later on querier.
-		return nil
+		return 0, 0
 	}
-	parser.Inspect(expr, func(node parser.Node, nodes []parser.Node) error {
-		e, ok := node.(*parser.SubqueryExpr)
-		if !ok {
-			return nil
+	var maxSteps int
+	totalSteps := traverseBottomUp(nil, &expr, func(parent *parser.Expr, node *parser.Expr) int {
+		e, ok := (*node).(*parser.SubqueryExpr)
+		if ok {
+			step := e.Step
+			if e.Step == 0 {
+				step = defaultSubQueryInterval
+			}
+			iters := int(e.Range / step)
+			if iters > maxSteps {
+				maxSteps = iters
+			}
+			return iters
 		}
-		step := e.Step
-		if e.Step == 0 {
-			step = defaultSubQueryInterval
-		}
-
-		if e.Range/step > time.Duration(maxStep) {
-			err = httpgrpc.Errorf(http.StatusBadRequest, ErrSubQueryStepTooSmall, maxStep)
-		}
-		return err
+		return 0
 	})
-	return err
+	return totalSteps, maxSteps
+}
+
+// Traverse the syntax tree from bottom up and calculate total subquery steps.
+func traverseBottomUp(parent *parser.Expr, current *parser.Expr, transform func(parent *parser.Expr, node *parser.Expr) int) int {
+	switch node := (*current).(type) {
+	case *parser.BinaryExpr:
+		iterLeft := traverseBottomUp(current, &node.LHS, transform)
+		iterRight := traverseBottomUp(current, &node.RHS, transform)
+		return iterLeft + iterRight
+	case *parser.AggregateExpr:
+		return traverseBottomUp(current, &node.Expr, transform)
+	case *parser.Call:
+		iters := 0
+		for i := range node.Args {
+			iters += traverseBottomUp(current, &node.Args[i], transform)
+		}
+		return iters
+	case *parser.StepInvariantExpr:
+		return traverseBottomUp(current, &node.Expr, transform)
+	case *parser.SubqueryExpr:
+		inner := traverseBottomUp(current, &node.Expr, transform)
+		cur := transform(parent, current)
+		if inner == 0 {
+			return cur
+		}
+		return inner * cur
+	case *parser.ParenExpr:
+		return traverseBottomUp(current, &node.Expr, transform)
+	case *parser.UnaryExpr:
+		return traverseBottomUp(current, &node.Expr, transform)
+	default:
+		return 0
+	}
 }

--- a/pkg/querier/tripperware/subquery_test.go
+++ b/pkg/querier/tripperware/subquery_test.go
@@ -12,11 +12,12 @@ import (
 func TestSubQueryStepSizeCheck(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
-		name        string
-		query       string
-		defaultStep time.Duration
-		err         error
-		maxStep     int64
+		name          string
+		query         string
+		defaultStep   time.Duration
+		err           error
+		maxStep       int
+		maxTotalSteps int
 	}{
 		{
 			name:  "invalid query",
@@ -27,46 +28,309 @@ func TestSubQueryStepSizeCheck(t *testing.T) {
 			query: "up",
 		},
 		{
-			name:    "valid subquery and within step limit",
-			query:   "up[60m:1m]",
-			maxStep: 100,
+			name:          "valid subquery and within step limit",
+			query:         "up[60m:1m]",
+			maxStep:       100,
+			maxTotalSteps: 10000,
 		},
 		{
 			name:    "valid subquery, not within step limit",
 			query:   "up[60m:1m]",
 			maxStep: 10,
-			err:     httpgrpc.Errorf(http.StatusBadRequest, ErrSubQueryStepTooSmall, 10),
+			err:     httpgrpc.Errorf(http.StatusBadRequest, ErrSubQueryStepTooSmall, 10, 60),
 		},
 		{
-			name:        "subquery with no step size defined, use default step and pass",
-			query:       "up[60m:]",
-			maxStep:     100,
-			defaultStep: time.Minute,
+			name:          "subquery with no step size defined, use default step and pass",
+			query:         "up[60m:]",
+			maxStep:       100,
+			maxTotalSteps: 10000,
+			defaultStep:   time.Minute,
 		},
 		{
 			name:        "subquery with no step size defined, use default step and fail",
 			query:       "up[60m:]",
 			maxStep:     100,
 			defaultStep: time.Second,
-			err:         httpgrpc.Errorf(http.StatusBadRequest, ErrSubQueryStepTooSmall, 100),
+			err:         httpgrpc.Errorf(http.StatusBadRequest, ErrSubQueryStepTooSmall, 100, 3600),
 		},
 		{
 			name:        "two subqueries within functions, one exceeds the limit while another is not",
 			query:       "sum_over_time(up[60m:]) + avg_over_time(test[5m:1m])",
 			maxStep:     10,
 			defaultStep: time.Second,
-			err:         httpgrpc.Errorf(http.StatusBadRequest, ErrSubQueryStepTooSmall, 10),
+			err:         httpgrpc.Errorf(http.StatusBadRequest, ErrSubQueryStepTooSmall, 10, 3600),
 		},
 		{
-			name:        "two subqueries within functions, all within the limit",
-			query:       "sum_over_time(up[60m:]) + avg_over_time(test[5m:1m])",
-			maxStep:     100,
-			defaultStep: time.Minute,
+			name:          "two subqueries within functions, all within the limit",
+			query:         "sum_over_time(up[60m:]) + avg_over_time(test[5m:1m])",
+			maxStep:       100,
+			maxTotalSteps: 10000,
+			defaultStep:   time.Minute,
+		},
+		{
+			name: "nested subqueries failed total steps",
+			query: `avg_over_time(
+sum by (cluster) (
+    increase(
+     test_metric[1m:10s])
+  )
+[1d:10s])`,
+			maxStep:       11000,
+			maxTotalSteps: 20000,
+			defaultStep:   time.Minute,
+			err:           httpgrpc.Errorf(http.StatusBadRequest, ErrSubQueryTotalStepsExceeded, 20000, 51840),
+		},
+		{
+			name:          "failed total steps",
+			query:         `avg_over_time(sum(increase(metric[1d:10s]))[1m:10s]) - max_over_time(rate(foo[1d:10s])[30s:10s])`,
+			maxStep:       11000,
+			maxTotalSteps: 20000,
+			defaultStep:   time.Minute,
+			err:           httpgrpc.Errorf(http.StatusBadRequest, ErrSubQueryTotalStepsExceeded, 20000, 77760),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := SubQueryStepSizeCheck(tc.query, tc.defaultStep, tc.maxStep)
+			err := SubQueryStepSizeCheck(tc.query, tc.defaultStep, tc.maxStep, tc.maxTotalSteps)
 			require.Equal(t, tc.err, err)
+		})
+	}
+}
+
+func TestGetSubQueryStepsFromQuery(t *testing.T) {
+	defaultStep := time.Minute
+	for _, tc := range []struct {
+		name               string
+		query              string
+		expectedTotalSteps int
+		expectedMaxStep    int
+	}{
+		{
+			name:  "vector",
+			query: "test_metric",
+		},
+		{
+			name:  "matrix",
+			query: "test_metric[10d]",
+		},
+		{
+			name:  "number literal",
+			query: "1",
+		},
+		{
+			name:               "subquery",
+			query:              "metric[1d:10s]",
+			expectedTotalSteps: 8640,
+			expectedMaxStep:    8640,
+		},
+		{
+			name:               "function with subquery",
+			query:              "avg_over_time(metric[1d:10s])",
+			expectedTotalSteps: 8640,
+			expectedMaxStep:    8640,
+		},
+		{
+			name:               "function 2 with subquery",
+			query:              "increase(metric[1d:10s])",
+			expectedTotalSteps: 8640,
+			expectedMaxStep:    8640,
+		},
+		{
+			name:               "aggregation, function with subquery",
+			query:              "sum(increase(metric[1d:10s]))",
+			expectedTotalSteps: 8640,
+			expectedMaxStep:    8640,
+		},
+		{
+			name:               "binary expression, aggregation, function with subquery",
+			query:              "sum(increase(metric[1d:10s])) + avg(increase(metric[2d:10s]))",
+			expectedTotalSteps: 8640 * 3,
+			expectedMaxStep:    8640 * 2,
+		},
+		{
+			name:               "nested function and subqueries",
+			query:              "avg_over_time(sum(increase(metric[1d:10s]))[1m:10s])",
+			expectedTotalSteps: 8640 * 6,
+			expectedMaxStep:    8640,
+		},
+		{
+			name:               "nested function and subqueries + vector",
+			query:              "avg_over_time(sum(increase(metric[1d:10s]))[1m:10s]) + foo",
+			expectedTotalSteps: 8640 * 6,
+			expectedMaxStep:    8640,
+		},
+		{
+			name:               "nested function and subqueries + function without subquery",
+			query:              "avg_over_time(sum(increase(metric[1d:10s]))[1m:10s]) + sum_over_time(foo[100d])",
+			expectedTotalSteps: 8640 * 6,
+			expectedMaxStep:    8640,
+		},
+		{
+			name:               "nested function and subqueries with binary expression",
+			query:              "avg_over_time(sum(increase(metric[1d:10s]))[1m:10s]) - max_over_time(rate(foo[1d:10s])[30s:10s])",
+			expectedTotalSteps: 8640*6 + 8640*3,
+			expectedMaxStep:    8640,
+		},
+		{
+			name:               "crazy",
+			expectedTotalSteps: 1296000,
+			expectedMaxStep:    8640,
+			query: `avg_over_time(
+  sum by (cluster) (
+    increase(
+      test_metric
+    [1m:10s])
+  )
+[1d:10s]) > ((((3 * (((2 * (((1 * avg_over_time(
+  sum by (cluster) (
+    increase(
+      test_metric
+    [1m:10s] offset 1w)
+  )
+[1d:10s])) + avg_over_time(
+  sum by (cluster) (
+    increase(
+      test_metric
+    [1m:10s] offset 2w)
+  )
+[1d:10s])) / 2)) + avg_over_time(
+  sum by (cluster) (
+    increase(
+      test_metric
+    [1m:10s] offset 3w)
+  )
+[1d:10s])) / 3)) + avg_over_time(
+  sum by (cluster) (
+    increase(
+      test_metric
+    [1m:10s] offset 4w)
+  )
+[1d:10s])) / 4) + (2.5 * sqrt((((3 * (((2 * (((1 * (stdvar_over_time(
+  sum by (cluster) (
+    increase(
+      test_metric
+    [1m:10s] offset 1w)
+  )
+[1d:10s]) + (avg_over_time(
+  sum by (cluster) (
+    increase(
+      test_metric
+    [1m:10s] offset 1w)
+  )
+[1d:10s]) * avg_over_time(
+  sum by (cluster) (
+    increase(
+      test_metric
+    [1m:10s] offset 1w)
+  )
+[1d:10s])))) + (stdvar_over_time(
+  sum by (cluster) (
+    increase(
+      test_metric
+    [1m:10s] offset 2w)
+  )
+[1d:10s]) + (avg_over_time(
+  sum by (cluster) (
+    increase(
+      test_metric
+    [1m:10s] offset 2w)
+  )
+[1d:10s]) * avg_over_time(
+  sum by (cluster) (
+    increase(
+      test_metric
+    [1m:10s] offset 2w)
+  )
+[1d:10s])))) / 2)) + (stdvar_over_time(
+  sum by (cluster) (
+    increase(
+      test_metric
+    [1m:10s] offset 3w)
+  )
+[1d:10s]) + (avg_over_time(
+  sum by (cluster) (
+    increase(
+      test_metric
+    [1m:10s] offset 3w)
+  )
+[1d:10s]) * avg_over_time(
+  sum by (cluster) (
+    increase(
+      test_metric
+    [1m:10s] offset 3w)
+  )
+[1d:10s])))) / 3)) + (stdvar_over_time(
+  sum by (cluster) (
+    increase(
+      test_metric
+    [1m:10s] offset 4w)
+  )
+[1d:10s]) + (avg_over_time(
+  sum by (cluster) (
+    increase(
+      test_metric
+    [1m:10s] offset 4w)
+  )
+[1d:10s]) * avg_over_time(
+  sum by (cluster) (
+    increase(
+      test_metric
+    [1m:10s] offset 4w)
+  )
+[1d:10s])))) / 4) - ((((3 * (((2 * (((1 * avg_over_time(
+  sum by (cluster) (
+    increase(
+      test_metric
+    [1m:10s] offset 1w)
+  )
+[1d:10s])) + avg_over_time(
+  sum by (cluster) (
+    increase(
+      test_metric
+    [1m:10s] offset 2w)
+  )
+[1d:10s])) / 2)) + avg_over_time(
+  sum by (cluster) (
+    increase(
+      test_metric
+    [1m:10s] offset 3w)
+  )
+[1d:10s])) / 3)) + avg_over_time(
+  sum by (cluster) (
+    increase(
+      test_metric
+    [1m:10s] offset 4w)
+  )
+[1d:10s])) / 4) * (((3 * (((2 * (((1 * avg_over_time(
+  sum by (cluster) (
+    increase(
+      test_metric
+    [1m:10s] offset 1w)
+  )
+[1d:10s])) + avg_over_time(
+  sum by (cluster) (
+    increase(
+      test_metric
+    [1m:10s] offset 2w)
+  )
+[1d:10s])) / 2)) + avg_over_time(
+  sum by (cluster) (
+    increase(
+      test_metric
+    [1m:10s] offset 3w)
+  )
+[1d:10s])) / 3)) + avg_over_time(
+  sum by (cluster) (
+    increase(
+      test_metric
+    [1m:10s] offset 4w)
+  )
+[1d:10s])) / 4)))))`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			totalSteps, maxStep := GetSubQueryStepsFromQuery(tc.query, defaultStep)
+			require.Equal(t, tc.expectedTotalSteps, totalSteps)
+			require.Equal(t, tc.expectedMaxStep, maxStep)
 		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

We still keep the old subquery step limit 11k as max allowed steps in the query, but introduce a new limit for the total steps in the query.

How total steps are calculated:
1. If it is binary expression, we do plus. `sum(increase(metric[1d:10s])) + avg(increase(metric[2d:10s]))` This will be `1d/10s` + `2d/10s` steps.
2. If it is nested subquery, we will do multiply. The one below will be `1m/10s` * `1d/10s` steps.

```
avg_over_time(
sum by (cluster) (
    increase(
     test_metric[1m:10s])
  )
[1d:10s])
```

The total steps limit is set to 1M, which should be able to throttle the bad query they were running. The limit is also configurable via flags in query frontend so we can easily change accordingly.

We also added logs to print number of max & total steps per query

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
